### PR TITLE
[python]: remove unused import

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -1,5 +1,4 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-import sys
 import os
 
 # Ensure we serve from the build directory


### PR DESCRIPTION
The best fix is to remove the unused `import sys` line from `serve.py` without changing any runtime behavior.

- **General approach:** delete imports that are not referenced.
- **Specific change:** in `serve.py`, remove line `import sys` and keep the remaining imports intact.
- **No additional methods/imports/definitions** are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._