### PR TITLE
player.gd: Use sprite node reference for animation, use call_deferred for hitbox

### DIFF
--- a/player.gd
+++ b/player.gd
@@ -56,8 +56,8 @@ func _on_animated_sprite_2d_animation_finished() -> void:
 func start(pos: Vector2) -> void:
 	position = pos
 	show()
-	$PlayerHitbox.set_deferred("disabled", false)
+	$PlayerHitbox.call_deferred("set_disabled", false)
 
 func hide_player():
 	hide()
-	$PlayerHitbox.set_deferred("disabled", true)
+	$PlayerHitbox.call_deferred("set_disabled", true)

--- a/player.gd
+++ b/player.gd
@@ -36,7 +36,7 @@ func _physics_process(delta: float) -> void:
 		
 	if not is_playing_special:
 		if velocity.length() > 0:
-			$AnimatedSprite2D.play("default")
+			sprite.play("default")
 		else:
 			sprite.stop()
 


### PR DESCRIPTION
_This PR applies 2/4 suggestions from code quality [AI findings](https://github.com/TitledGames/Microwave-Man/security/quality/ai-findings). 2 suggestions were skipped to avoid creating conflicts._