### PR TITLE
main_menu.gd: Set accurate Discord RPC state to 'In Main Menu' at main menu

### DIFF
--- a/main_menu.gd
+++ b/main_menu.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 		var discord_rpc = Engine.get_singleton("DiscordRPC")
 		discord_rpc.set("app_id", 1465471267183263922)
 		discord_rpc.set("details", "Play as a microwave!")
-		discord_rpc.set("state", "Playing the game!")
+		discord_rpc.set("state", "In Main Menu")
 		discord_rpc.set("large_image", "ground")
 		discord_rpc.set("large_image_text", "Play now!")
 		discord_rpc.set("small_image", "level")


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/TitledGames/Microwave-Man/security/quality/ai-findings)._