### PR TITLE
main.gd: Add Discord RPC in-game state when level is running

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -37,6 +37,18 @@ func new_game():
 
 func _on_start_timer_timeout() -> void:
 	GameState.is_level_running = true
+	_update_discord_state()
+
+func _update_discord_state() -> void:
+	if not OS.has_feature("web") and Engine.has_singleton("DiscordRPC"):
+		var discord_rpc = Engine.get_singleton("DiscordRPC")
+		discord_rpc.set("state", "In Game")
+		discord_rpc.set("details", "Collecting coins!")
+		discord_rpc.set("large_image", "ground")
+		discord_rpc.set("large_image_text", "Play now!")
+		discord_rpc.set("small_image", "coin")
+		discord_rpc.set("small_image_text", "Coins collected: " + str(GameState.coins))
+		discord_rpc.call("refresh")
 
 func _on_coin_collected() -> void:
 	$HUD.update_coins(GameState.coins)


### PR DESCRIPTION
Updates Discord Rich Presence to show "In Game" with "Collecting coins!" details when the level starts running (on start timer timeout). Uses "coin" small image and shows the current coin count.