### PR TITLE
Improve null safety, error handling, and naming consistency across coin.gd, main_menu.gd, and game_state.gd

### DIFF
--- a/coin.gd
+++ b/coin.gd
@@ -32,11 +32,16 @@ func _on_body_entered(body: Node2D) -> void:
 		var sound_instance = COIN_SOUND_SCENE.instantiate()
 
 		# Add it to the main tree (it starts playing immediately due to Autoplay)
-		get_tree().current_scene.add_child(sound_instance)
+		var scene_root = get_tree().current_scene
+		if scene_root != null:
+			scene_root.add_child(sound_instance)
+		elif get_parent() != null:
+			get_parent().add_child(sound_instance)
+		else:
+			sound_instance.queue_free()
 
-		# Track the collected coin in the global game state
-		GameState.coins += 1
-		GameState.coin_collected.emit()
+		# Track the collected coin in the global game state via a centralized method
+		GameState.collect_coin()
 
 		# This deletes the coin from the world
 		queue_free()

--- a/game_state.gd
+++ b/game_state.gd
@@ -11,6 +11,10 @@ var is_level_running: bool = false
 const HIGHSCORE_PATH = "user://highscores.json"
 const MAX_HIGHSCORES = 10
 
+func collect_coin() -> void:
+	coins += 1
+	coin_collected.emit()
+
 func format_time(seconds: float) -> String:
 	var total_seconds: int = int(seconds)
 	var mins: int = total_seconds / 60

--- a/main_menu.gd
+++ b/main_menu.gd
@@ -1,5 +1,7 @@
 extends Node2D
 
+const DISCORD_APP_ID = 1465471267183263922
+
 func _ready() -> void:
 	var version = ProjectSettings.get_setting("application/config/version", "")
 	if version != "":
@@ -7,7 +9,7 @@ func _ready() -> void:
 
 	if not OS.has_feature("web") and Engine.has_singleton("DiscordRPC"):
 		var discord_rpc = Engine.get_singleton("DiscordRPC")
-		discord_rpc.set("app_id", 1465471267183263922)
+		discord_rpc.set("app_id", DISCORD_APP_ID)
 		discord_rpc.set("details", "Play as a microwave!")
 		discord_rpc.set("state", "In Main Menu")
 		discord_rpc.set("large_image", "ground")
@@ -21,7 +23,11 @@ func _on_quit_pressed() -> void:
 	get_tree().quit()
 
 func _on_playgame_pressed() -> void:
-	get_tree().change_scene_to_file("res://main.tscn")
+	var err = get_tree().change_scene_to_file("res://main.tscn")
+	if err != OK:
+		push_error("Failed to change scene to res://main.tscn (error code: %s)" % err)
 
 func _on_extras_pressed() -> void:
-	get_tree().change_scene_to_file("res://about.tscn")
+	var err = get_tree().change_scene_to_file("res://about.tscn")
+	if err != OK:
+		push_error("Failed to change scene to res://about.tscn (error code: %s)" % err)

--- a/main_menu.tscn
+++ b/main_menu.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="Script" uid="uid://ckxckman8wf65" path="res://main_menu.gd" id="1_7vrkn"]
 [ext_resource type="Texture2D" uid="uid://ctqd07ry8i37o" path="res://assets/icon.png" id="2_fu7sn"]
 
-[node name="main menu" type="Node2D" unique_id=432237393]
+[node name="main_menu" type="Node2D" unique_id=432237393]
 script = ExtResource("1_7vrkn")
 
 [node name="Icon" type="Sprite2D" parent="." unique_id=193098593]


### PR DESCRIPTION
Applies the following fixes:

- **coin.gd**: Null-safe `current_scene` access when adding coin sound (falls back to `get_parent()`, then queues free)
- **coin.gd**: Replace inline `GameState.coins += 1` / `emit()` with centralized `GameState.collect_coin()`
- **game_state.gd**: Add `collect_coin()` method to support centralized coin tracking
- **main_menu.gd**: Extract hardcoded Discord app ID (`1465471267183263922`) into `DISCORD_APP_ID` constant
- **main_menu.gd**: Add error handling with `push_error()` for `change_scene_to_file()` calls
- **main_menu.tscn**: Rename root node from `"main menu"` to `"main_menu"` for naming consistency