### PR TITLE
Rename _on_extras_pressed to _on_about_pressed, optimize timer, extract Discord keys, sync coin presence, deduplicate animation

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -1,6 +1,12 @@
 extends Node
 
 const SPAWN_POSITION = Vector2(-589, 471.99997)
+const DISCORD_STATE_KEY = "state"
+const DISCORD_DETAILS_KEY = "details"
+const DISCORD_LARGE_IMAGE_KEY = "large_image"
+const DISCORD_LARGE_IMAGE_TEXT_KEY = "large_image_text"
+const DISCORD_SMALL_IMAGE_KEY = "small_image"
+const DISCORD_SMALL_IMAGE_TEXT_KEY = "small_image_text"
 
 func _ready():
 	GameState.restart_game.connect(new_game)
@@ -19,7 +25,8 @@ func _process(delta: float) -> void:
 	if GameState.is_level_running:
 		var prev_second = int(GameState.elapsed_time)
 		GameState.elapsed_time += delta
-		if int(GameState.elapsed_time) != prev_second:
+		var current_second = int(GameState.elapsed_time)
+		if current_second != prev_second:
 			$HUD.update_timer(GameState.elapsed_time)
 
 func new_game():
@@ -42,13 +49,14 @@ func _on_start_timer_timeout() -> void:
 func _update_discord_state() -> void:
 	if not OS.has_feature("web") and Engine.has_singleton("DiscordRPC"):
 		var discord_rpc = Engine.get_singleton("DiscordRPC")
-		discord_rpc.set("state", "In Game")
-		discord_rpc.set("details", "Collecting coins!")
-		discord_rpc.set("large_image", "ground")
-		discord_rpc.set("large_image_text", "Play now!")
-		discord_rpc.set("small_image", "coin")
-		discord_rpc.set("small_image_text", "Coins collected: " + str(GameState.coins))
-		discord_rpc.call("refresh")
+		discord_rpc.set(DISCORD_STATE_KEY, "In Game")
+		discord_rpc.set(DISCORD_DETAILS_KEY, "Collecting coins!")
+		discord_rpc.set(DISCORD_LARGE_IMAGE_KEY, "ground")
+		discord_rpc.set(DISCORD_LARGE_IMAGE_TEXT_KEY, "Play now!")
+		discord_rpc.set(DISCORD_SMALL_IMAGE_KEY, "coin")
+		discord_rpc.set(DISCORD_SMALL_IMAGE_TEXT_KEY, "Coins collected: " + str(GameState.coins))
+		discord_rpc.refresh()
 
 func _on_coin_collected() -> void:
 	$HUD.update_coins(GameState.coins)
+	_update_discord_state()

--- a/main_menu.gd
+++ b/main_menu.gd
@@ -27,7 +27,7 @@ func _on_playgame_pressed() -> void:
 	if err != OK:
 		push_error("Failed to change scene to res://main.tscn (error code: %s)" % err)
 
-func _on_extras_pressed() -> void:
+func _on_about_pressed() -> void:
 	var err = get_tree().change_scene_to_file("res://about.tscn")
 	if err != OK:
 		push_error("Failed to change scene to res://about.tscn (error code: %s)" % err)

--- a/main_menu.tscn
+++ b/main_menu.tscn
@@ -70,5 +70,5 @@ theme_override_font_sizes/font_size = 18
 horizontal_alignment = 2
 
 [connection signal="pressed" from="playgame" to="." method="_on_playgame_pressed"]
-[connection signal="pressed" from="about" to="." method="_on_extras_pressed"]
+[connection signal="pressed" from="about" to="." method="_on_about_pressed"]
 [connection signal="pressed" from="quit" to="." method="_on_quit_pressed"]

--- a/player.gd
+++ b/player.gd
@@ -35,10 +35,13 @@ func _physics_process(delta: float) -> void:
 		sprite.flip_h = true
 		
 	if not is_playing_special:
-		if velocity.length() > 0:
-			sprite.play("default")
-		else:
-			sprite.stop()
+		update_animation()
+
+func update_animation() -> void:
+	if velocity.length() > 0:
+		sprite.play("default")
+	else:
+		sprite.stop()
 
 func play_collect_animation():
 	is_playing_special = true
@@ -47,11 +50,7 @@ func play_collect_animation():
 func _on_animated_sprite_2d_animation_finished() -> void:
 	if sprite.animation == "coin":
 		is_playing_special = false
-		
-		if velocity.length() > 0:
-			sprite.play("default")
-		else:
-			sprite.stop() 
+		update_animation()
 		
 func start(pos: Vector2) -> void:
 	position = pos


### PR DESCRIPTION
Applies the following fixes:

- **main_menu.tscn + main_menu.gd**: Rename signal connection and method from `_on_extras_pressed` to `_on_about_pressed` to match the `about` button node name
- **main.gd**: Store `int(GameState.elapsed_time)` result to avoid redundant calculation per frame
- **main.gd**: Extract Discord RPC property key strings into named constants for maintainability
- **main.gd**: Use `discord_rpc.refresh()` instead of `discord_rpc.call("refresh")`
- **main.gd**: Call `_update_discord_state()` on coin collect so Discord presence stays in sync with coin count
- **player.gd**: Extract duplicated animation logic into `update_animation()` method, called from both `_physics_process` and `_on_animated_sprite_2d_animation_finished`