### PR TITLE
Use consistent Discord refresh call, optimize velocity check, fix hitbox set_deferred

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -55,7 +55,7 @@ func _update_discord_state() -> void:
 		discord_rpc.set(DISCORD_LARGE_IMAGE_TEXT_KEY, "Play now!")
 		discord_rpc.set(DISCORD_SMALL_IMAGE_KEY, "coin")
 		discord_rpc.set(DISCORD_SMALL_IMAGE_TEXT_KEY, "Coins collected: " + str(GameState.coins))
-		discord_rpc.refresh()
+		discord_rpc.call("refresh")
 
 func _on_coin_collected() -> void:
 	$HUD.update_coins(GameState.coins)

--- a/player.gd
+++ b/player.gd
@@ -38,7 +38,7 @@ func _physics_process(delta: float) -> void:
 		update_animation()
 
 func update_animation() -> void:
-	if velocity.length() > 0:
+	if velocity.length_squared() > 0:
 		sprite.play("default")
 	else:
 		sprite.stop()
@@ -55,8 +55,8 @@ func _on_animated_sprite_2d_animation_finished() -> void:
 func start(pos: Vector2) -> void:
 	position = pos
 	show()
-	$PlayerHitbox.call_deferred("set_disabled", false)
+	$PlayerHitbox.set_deferred("disabled", false)
 
 func hide_player():
 	hide()
-	$PlayerHitbox.call_deferred("set_disabled", true)
+	$PlayerHitbox.set_deferred("disabled", true)


### PR DESCRIPTION
Applies the following fixes:

- **main.gd**: Use `discord_rpc.call("refresh")` instead of `discord_rpc.refresh()` for consistency with `main_menu.gd`
- **player.gd**: Use `velocity.length_squared() > 0` instead of `velocity.length() > 0` to avoid unnecessary square root computation
- **player.gd**: Use `set_deferred("disabled", ...)` instead of `call_deferred("set_disabled", ...)` — the correct property-based approach for CollisionShape2D