### PR TITLE
Fix deceleration constant, add scene error checks, update Discord state on new_game

### DIFF
--- a/end.gd
+++ b/end.gd
@@ -1,7 +1,8 @@
 extends Area2D
 
-func _on_body_entered(body):
-	# Check if the body overlapping the level end trigger is actually the player
+func _on_body_entered(body: Node2D) -> void:
 	if body.is_in_group("player"):
 		GameState.is_level_running = false
-		get_tree().change_scene_to_file("res://endcreen.tscn")
+		var err = get_tree().change_scene_to_file("res://endcreen.tscn")
+		if err != OK:
+			push_error("Failed to load endcreen.tscn (error code: %s)" % err)

--- a/endcreen.gd
+++ b/endcreen.gd
@@ -37,10 +37,14 @@ func _on_save_score_pressed() -> void:
 
 func _on_play_again_pressed() -> void:
 	GameState.restart_game.emit()
-	get_tree().change_scene_to_file("res://main.tscn")
+	var err = get_tree().change_scene_to_file("res://main.tscn")
+	if err != OK:
+		push_error("Failed to load main.tscn (error code: %s)" % err)
 
 func _on_back_to_main_menu_pressed() -> void:
-	get_tree().change_scene_to_file("res://main_menu.tscn")
+	var err = get_tree().change_scene_to_file("res://main_menu.tscn")
+	if err != OK:
+		push_error("Failed to load main_menu.tscn (error code: %s)" % err)
 
 func _on_quit_pressed() -> void:
 	get_tree().quit()

--- a/main.gd
+++ b/main.gd
@@ -40,6 +40,7 @@ func new_game():
 
 	$HUD.update_coins(0)
 	$HUD.update_timer(0.0)
+	_update_discord_state()
 	$StartTimer.start()
 
 func _on_start_timer_timeout() -> void:

--- a/player.gd
+++ b/player.gd
@@ -3,7 +3,7 @@ extends CharacterBody2D
 const SPEED = 200.0
 const JUMP_VELOCITY = -350.0
 const GRAVITY = 980
-const DECELERATION = 1200.0
+const DECELERATION = 12000.0
 
 @onready var audio_player: AudioStreamPlayer = $AudioStreamPlayer
 @onready var sprite: AnimatedSprite2D = $AnimatedSprite2D


### PR DESCRIPTION
## Changes

Fixes identified in code review of changes since 1.3.0:

- **player.gd**: Fix DECELERATION constant (1200 → 12000) to match original frame-rate-dependent behavior. Old code subtracted SPEED (200) per frame; new delta-based code at 12000 restores ~200/frame at 60 FPS.
- **end.gd**: Add type annotation and error check for scene change (consistent with main_menu.gd pattern).
- **endcreen.gd**: Add error checks for scene changes (consistent with main_menu.gd pattern).
- **main.gd**: Call `_update_discord_state()` at end of `new_game()` so Discord state updates immediately instead of waiting for the 2-second start timer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for scene transitions, ensuring the game properly reports and handles failures when loading new levels or menus

* **Gameplay**
  * Enhanced character control by increasing horizontal deceleration, allowing the player character to stop more quickly when movement input ceases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->