### PR TITLE
[1.4.0]: Fix build number cutoff by right-justifying BuildLabel

### DIFF
--- a/about.tscn
+++ b/about.tscn
@@ -44,7 +44,6 @@ text = "Back"
 flat = true
 
 [node name="BuildLabel" type="Label" parent="." unique_id=1086229892]
-offset_left = 962.0
 offset_right = 1152.0
 offset_bottom = 40.0
 theme_override_fonts/font = ExtResource("1_4q2eq")

--- a/main_menu.tscn
+++ b/main_menu.tscn
@@ -62,8 +62,7 @@ text = "Microwave-Man!"
 horizontal_alignment = 1
 
 [node name="BuildLabel" type="Label" parent="." unique_id=504746542]
-offset_left = 847.0
-offset_right = 1147.0
+offset_right = 1152.0
 offset_bottom = 31.0
 theme_override_fonts/font = ExtResource("1_06t4h")
 theme_override_font_sizes/font_size = 18


### PR DESCRIPTION
Fixes #132

## Problem
The BuildLabel in `main_menu.tscn` and `about.tscn` had a narrow fixed `offset_left` (847/962), so long beta build numbers injected by CI were cut off at the right edge.

## Solution
Removed `offset_left` so the label spans from x=0 across the full screen width while keeping `horizontal_alignment = 2` (right-justified). This way the build number always appears at the bottom-right corner but can grow leftward without being truncated.

## Verification
The label now has no left offset, giving it full width (0 to 1152). With right-alignment, any build number — no matter how long — will be visible, anchored to the right edge and extending left as needed.