### PR TITLE
[1.4.0]: Fix timer not starting for 2 seconds when entering the game

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -16,10 +16,10 @@ func _ready():
 	GameState.total_coins = get_tree().get_nodes_in_group("coins").size()
 	GameState.coins = 0
 	GameState.elapsed_time = 0.0
-	GameState.is_level_running = false
+	GameState.is_level_running = true
 	$HUD.update_coins(0)
 	$HUD.update_timer(0.0)
-	$StartTimer.start()
+	_update_discord_state()
 
 func _process(delta: float) -> void:
 	if GameState.is_level_running:
@@ -32,7 +32,7 @@ func _process(delta: float) -> void:
 func new_game():
 	GameState.coins = 0
 	GameState.elapsed_time = 0.0
-	GameState.is_level_running = false
+	GameState.is_level_running = true
 
 	var player = get_node("Player")
 	if player:
@@ -40,11 +40,6 @@ func new_game():
 
 	$HUD.update_coins(0)
 	$HUD.update_timer(0.0)
-	_update_discord_state()
-	$StartTimer.start()
-
-func _on_start_timer_timeout() -> void:
-	GameState.is_level_running = true
 	_update_discord_state()
 
 func _update_discord_state() -> void:

--- a/main.tscn
+++ b/main.tscn
@@ -23,10 +23,6 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.5, 0.7, 1, 1)
 
-[node name="StartTimer" type="Timer" parent="."]
-wait_time = 2.0
-one_shot = true
-
 [node name="HUD" parent="." instance=ExtResource("4_1bvp3")]
 
 [node name="Node2D" parent="." instance=ExtResource("7_272bh")]
@@ -69,5 +65,4 @@ zoom = Vector2(3, 3)
 [node name="end" parent="." instance=ExtResource("7_5vw27")]
 position = Vector2(-267, -745)
 
-[connection signal="timeout" from="StartTimer" to="." method="_on_start_timer_timeout"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]


### PR DESCRIPTION
Fixes an issue where the in-game timer doesn't start counting for 2 seconds after pressing Play.

## Problem
`main.gd._ready()` started a `StartTimer` node with a 2-second `wait_time`. Only when that timer timed out was `GameState.is_level_running` set to `true`. This meant the `_process(delta)` loop ignored all time for the first 2 seconds of gameplay.

## Solution
- Set `GameState.is_level_running = true` immediately in `_ready()` and `new_game()`
- Removed the `_on_start_timer_timeout()` callback (no longer needed)
- Removed the `StartTimer` node from `main.tscn` and its signal connection

## Changes
| File | Change |
|------|--------|
| `main.gd:19` | `is_level_running = false` → `true` |
| `main.gd:22` | `$StartTimer.start()` → `_update_discord_state()` |
| `main.gd:35` | `is_level_running = false` → `true` in `new_game()` |
| `main.gd:44` | Removed `$StartTimer.start()` from `new_game()` |
| `main.gd:46-48` | Removed `_on_start_timer_timeout()` |
| `main.tscn` | Removed `StartTimer` node and its `timeout` signal connection |