### PR TITLE
Fix gh-pages deployment: authenticate git push with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,5 +308,6 @@ jobs:
               fi
               git commit -m "Deploy ${GITHUB_REF#refs/tags/} to $DEPLOY_LOCATION"
             fi
+            git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
             git push origin gh-pages
           fi


### PR DESCRIPTION
The `deploy-to-gh-pages` job fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The checkout step uses `persist-credentials: false`, so no credentials are available when `git push origin gh-pages` runs. This sets the remote URL to include the `GITHUB_TOKEN` (which is automatically provided by GitHub Actions via the `contents: write` permission) before pushing.