### PR TITLE
Fix gh-pages deployment: use actions/checkout default credential persistence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history to check for gh-pages branch
-          persist-credentials: false
           
       - name: Download Web Artifact
         uses: actions/download-artifact@v8
@@ -324,6 +323,5 @@ jobs:
               fi
               git commit -m "Deploy ${GITHUB_REF#refs/tags/} to $DEPLOY_LOCATION"
             fi
-            git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
             git push origin gh-pages
           fi


### PR DESCRIPTION
The `deploy-to-gh-pages` job fails with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

**Root cause:** The checkout step used `persist-credentials: false`, which prevents `actions/checkout` from configuring the `GITHUB_TOKEN` in git's credential helper. When `git push origin gh-pages` runs later, no credentials are available.

**Previous attempt (PR #137):** Added a manual `git remote set-url` to inject the token, but it failed with "Invalid username or token" — likely because `GITHUB_TOKEN` was not being expanded correctly in the shell context.

**This fix:** Simply removes `persist-credentials: false` from the deploy job's checkout step. With the default (`true`), `actions/checkout` automatically persists the `GITHUB_TOKEN` into git's config, so `git push` authenticates without any manual intervention. Also removes the now-unnecessary `git remote set-url` line from PR #137.